### PR TITLE
DM-4133 Change type of LTV1/2 from int to float. Rely on makeWcs to strip WCS headers.

### DIFF
--- a/python/lsst/daf/butlerUtils/cameraMapper.py
+++ b/python/lsst/daf/butlerUtils/cameraMapper.py
@@ -895,10 +895,7 @@ def exposureFromImage(image):
         exposure = image
     md = image.getMetadata()
     exposure.setMetadata(md)
-    wcs = afwImage.makeWcs(md)
+    wcs = afwImage.makeWcs(md, True)
     exposure.setWcs(wcs)
-    wcsMetadata = wcs.getFitsMetadata()
-    for kw in wcsMetadata.paramNames():
-        md.remove(kw)
 
     return exposure


### PR DESCRIPTION
This removes a more complete set -- including LTV information, which is used
in constructing the Wcs but not stored within it -- than the previous
approach.