### PR TITLE
DM-4732: butler parentSearch incorrectly returns '[]' instead of 'None' in one case.

### DIFF
--- a/python/lsst/daf/butlerUtils/cameraMapper.py
+++ b/python/lsst/daf/butlerUtils/cameraMapper.py
@@ -421,9 +421,15 @@ class CameraMapper(dafPersist.Mapper):
             if os.path.realpath(pathPrefix) != os.path.realpath(root):
                 # No prefix matching root, don't search for parents
                 paths = glob.glob(path)
-                if len(paths) > 0:
+                # The contract states that `None` will be returned
+                #   if no matches are found.
+                # Thus we explicitly set up this if/else to return `None` 
+                #   if `not paths` instead of `[]`.
+                # An argument could be made that the contract should be changed
+                if paths:
                     return paths
-                return []
+                else:
+                    return None
             if pathPrefix == "/":
                 path = path[1:]
             elif pathPrefix != "":

--- a/python/lsst/daf/butlerUtils/mapping.py
+++ b/python/lsst/daf/butlerUtils/mapping.py
@@ -126,8 +126,9 @@ class Mapping(object):
             path = os.path.join(self.root, path)
         if not write:
             newPath = mapper._parentSearch(path)
-            if newPath is not None:
+            if newPath:
                 path = newPath
+        assert path, "Fully-qualified filename is empty."
 
         addFunc = "add_" + self.datasetType # Name of method for additionalData
         if hasattr(mapper, addFunc):


### PR DESCRIPTION
Fix return values of parentSearch to always be `None` for failures.

Robustify `mapping.map` to check `if newPath:` rather than `if newPath is not None:`.  This simplified check catches `None` and `[]`.  Previously, the bug in parentSearch would sometimes return `[]`.  But, more generally, this `if newPath:` is in conformance with PEP-008

https://www.python.org/dev/peps/pep-0008/