### PR TITLE
testGetDatasetTypes include datasets from base

### DIFF
--- a/python/lsst/daf/butlerUtils/cameraMapper.py
+++ b/python/lsst/daf/butlerUtils/cameraMapper.py
@@ -163,13 +163,16 @@ class CameraMapper(dafPersist.Mapper):
 
         self.root = root
         if isinstance(policy, pexPolicy.Policy):
-            policy = dafPersist.Policy(pexPolicy=policy)
+            policy = dafPersist.Policy(policy)
 
         repoPolicy = CameraMapper.getRepoPolicy(self.root, self.root)
         if repoPolicy is not None:
             policy.update(repoPolicy)
 
-        dictPolicy = dafPersist.Policy(defaultInitData=("daf_butlerUtils", "MapperDictionary.paf", "policy"))
+        defaultPolicyFile = dafPersist.Policy.defaultPolicyFile("daf_butlerUtils", 
+                                                                "MapperDictionary.paf", 
+                                                                "policy")
+        dictPolicy = dafPersist.Policy(defaultPolicyFile)
         policy.merge(dictPolicy)
 
         # Levels
@@ -245,17 +248,14 @@ class CameraMapper(dafPersist.Mapper):
             calibRegistry = None
 
         # Sub-dictionaries (for exposure/calibration/dataset types)
-        imgMappingPolicy = dafPersist.Policy(defaultInitData=("daf_butlerUtils", "ImageMappingDictionary.paf",
-                                                              "policy"))
-        expMappingPolicy = dafPersist.Policy(defaultInitData=("daf_butlerUtils",
-                                                              "ExposureMappingDictionary.paf",
-                                                              "policy"))
-        calMappingPolicy = dafPersist.Policy(defaultInitData=("daf_butlerUtils",
-                                                              "CalibrationMappingDictionary.paf",
-                                                              "policy"))
-        dsMappingPolicy = dafPersist.Policy(defaultInitData=("daf_butlerUtils",
-                                                             "DatasetMappingDictionary.paf",
-                                                             "policy"))
+        imgMappingPolicy = dafPersist.Policy(dafPersist.Policy.defaultPolicyFile(
+            "daf_butlerUtils", "ImageMappingDictionary.paf", "policy"))
+        expMappingPolicy = dafPersist.Policy(dafPersist.Policy.defaultPolicyFile(
+            "daf_butlerUtils", "ExposureMappingDictionary.paf", "policy"))
+        calMappingPolicy = dafPersist.Policy(dafPersist.Policy.defaultPolicyFile(
+            "daf_butlerUtils", "CalibrationMappingDictionary.paf", "policy"))
+        dsMappingPolicy = dafPersist.Policy(dafPersist.Policy.defaultPolicyFile(
+             "daf_butlerUtils", "DatasetMappingDictionary.paf", "policy"))
 
         # Dict of valid keys and their value types
         self.keyDict = dict()
@@ -275,7 +275,7 @@ class CameraMapper(dafPersist.Mapper):
                 # Centrally-defined datasets
                 defaultsPath = os.path.join(getPackageDir("daf_butlerUtils"), "policy", name + ".yaml")
                 if os.path.exists(defaultsPath):
-                    datasets.merge(dafPersist.Policy(filePath=defaultsPath))
+                    datasets.merge(dafPersist.Policy(defaultsPath))
 
                 mappings = dict()
                 setattr(self, name, mappings)
@@ -381,6 +381,14 @@ class CameraMapper(dafPersist.Mapper):
 
     @staticmethod
     def getRepoPolicy(root, repos):
+        """Get the policy stored in a repo (specified by 'root'), if there is one.
+        
+        @param root (string) path to the root location of the repository
+        @param repos (string) path from the root of the repo to the folder containing a file named 
+                              _policy.paf or _policy.yaml
+        @return (lsst.daf.persistence.Policy or None) A Policy instantiated with the policy found according to
+                                                      input variables, or None if a policy file was not found.
+        """
         policy = None
         if root is not None:
             paths = CameraMapper.parentSearch(root, os.path.join(repos, '_policy.*'))
@@ -390,7 +398,7 @@ class CameraMapper(dafPersist.Mapper):
                     if len(matches) > 1:
                         raise RuntimeError("More than 1 policy possibility for root:%s" % root)
                     elif len(matches) == 1:
-                        policy = dafPersist.Policy(filePath=matches[0])
+                        policy = dafPersist.Policy(matches[0])
                         break
         return policy
 

--- a/tests/BaseMapper.paf
+++ b/tests/BaseMapper.paf
@@ -1,0 +1,7 @@
+#<?cfg paf policy ?>
+
+#   Mapper policy whose only dataset comes from the base mapper class
+
+camera: "camera"
+defaultLevel: "sensor"
+datasets: {}

--- a/tests/testCameraMapper.py
+++ b/tests/testCameraMapper.py
@@ -40,6 +40,14 @@ testDir = os.path.relpath(os.path.join(getPackageDir('daf_butlerUtils'), 'tests'
 def setup_module(module):
     lsst.utils.tests.init()
 
+class BaseMapper(butlerUtils.CameraMapper):
+    packageName = 'base'
+
+    def __init__(self):
+        policy = dafPersist.Policy(filePath=os.path.join(testDir, "BaseMapper.paf"))
+        butlerUtils.CameraMapper.__init__(self,
+                                          policy=policy, repositoryDir="tests", root="tests")
+        return
 
 class MinMapper1(butlerUtils.CameraMapper):
     packageName = 'larry'
@@ -104,16 +112,11 @@ class Mapper1TestCase(unittest.TestCase):
         del self.mapper
 
     def testGetDatasetTypes(self):
-        self.assertEqual(set(self.mapper.getDatasetTypes()),
-                         set(["x", "x_filename", "badSourceHist", "defects",
-                              "badSourceHist_filename", "camera", "skypolicy", "expIdInfo",
-                              "packages", "packages_filename",
-                              "processCcd_config", "processCcd_config_filename",
-                              "calibrate_config", "calibrate_config_filename",
-                              "characterizeImage_config", "characterizeImage_config_filename",
-                              "IngestIndexedReferenceTask_config",
-                              "IngestIndexedReferenceTask_config_filename",
-                              ]))
+        expectedTypes = BaseMapper().getDatasetTypes()
+        #   Add the expected additional types to what the base class provides
+        expectedTypes.extend(["x", "x_filename",
+                              "badSourceHist", "badSourceHist_filename",])
+        self.assertEqual(set(self.mapper.getDatasetTypes()), set(expectedTypes))
 
     def testMap(self):
         loc = self.mapper.map("x", {"sensor": "1,1"}, write=True)
@@ -158,19 +161,16 @@ class Mapper2TestCase(unittest.TestCase):
         del self.mapper
 
     def testGetDatasetTypes(self):
-        self.assertEqual(set(self.mapper.getDatasetTypes()),
-                         set(["flat", "flat_filename", "raw", "raw_md",
-                              "raw_filename", "raw_sub", "defects",
+        expectedTypes = BaseMapper().getDatasetTypes()
+        #   Add the expected additional types to what the base class provides
+        expectedTypes.extend(["flat", "flat_filename", "raw", "raw_md",
+                              "raw_filename", "raw_sub",
                               "some", "some_filename", "some_md", "some_sub",
-                              "camera", "src", "src_filename", "skypolicy",
-                              "other_sub", "other_filename", "other_md",
-                              "other", "expIdInfo", "packages", "packages_filename",
-                              "processCcd_config", "processCcd_config_filename",
-                              "calibrate_config", "calibrate_config_filename",
-                              "characterizeImage_config", "characterizeImage_config_filename",
-                              "IngestIndexedReferenceTask_config",
-                              "IngestIndexedReferenceTask_config_filename",
-                              ]))
+                              "src", "src_filename",
+                              "other_sub", "other_filename", "other_md", "other",
+                              ])
+        self.assertEqual(set(self.mapper.getDatasetTypes()),
+                         set(expectedTypes))
 
     def testMap(self):
         loc = self.mapper.map("raw", {"ccd": 13}, write=True)

--- a/tests/testCameraMapper.py
+++ b/tests/testCameraMapper.py
@@ -53,9 +53,8 @@ class MinMapper1(butlerUtils.CameraMapper):
     packageName = 'larry'
 
     def __init__(self):
-        policy = dafPersist.Policy(filePath=os.path.join(testDir, "MinMapper1.paf"))
-        butlerUtils.CameraMapper.__init__(self,
-                                          policy=policy, repositoryDir=testDir, root=testDir)
+        policy = dafPersist.Policy(os.path.join(testDir, "MinMapper1.paf"))
+        butlerUtils.CameraMapper.__init__(self, policy=policy, repositoryDir=testDir, root=testDir)
         return
 
     def std_x(self, item, dataId):
@@ -73,7 +72,7 @@ class MinMapper2(butlerUtils.CameraMapper):
     # CalibRoot in policy
     # needCalibRegistry
     def __init__(self):
-        policy = dafPersist.Policy(filePath=os.path.join(testDir, "MinMapper2.paf"))
+        policy = dafPersist.Policy(os.path.join(testDir, "MinMapper2.paf"))
         butlerUtils.CameraMapper.__init__(self, policy=policy, repositoryDir=testDir, root=testDir,
                                           registry=os.path.join(testDir, "cfhtls.sqlite3"))
         return
@@ -97,7 +96,7 @@ class MinMapper2(butlerUtils.CameraMapper):
 class MinMapper3(butlerUtils.CameraMapper):
 
     def __init__(self):
-        policy = dafPersist.Policy(filePath=os.path.join(testDir, "MinMapper1.paf"))
+        policy = dafPersist.Policy(os.path.join(testDir, "MinMapper1.paf"))
         butlerUtils.CameraMapper.__init__(self, policy=policy, repositoryDir=testDir, root=testDir)
         return
 

--- a/tests/testCameraMapper.py
+++ b/tests/testCameraMapper.py
@@ -44,9 +44,8 @@ class BaseMapper(butlerUtils.CameraMapper):
     packageName = 'base'
 
     def __init__(self):
-        policy = dafPersist.Policy(filePath=os.path.join(testDir, "BaseMapper.paf"))
-        butlerUtils.CameraMapper.__init__(self,
-                                          policy=policy, repositoryDir="tests", root="tests")
+        policy = dafPersist.Policy(os.path.join(testDir, "BaseMapper.paf"))
+        butlerUtils.CameraMapper.__init__(self, policy=policy, repositoryDir=testDir, root=testDir)
         return
 
 class MinMapper1(butlerUtils.CameraMapper):


### PR DESCRIPTION
This test was failing when the inherited datasets from the
base class were modified.  Change test to automatically include
inherited datasets in the comparison.